### PR TITLE
Various

### DIFF
--- a/src/Blazon.php
+++ b/src/Blazon.php
@@ -16,7 +16,7 @@ class Blazon
     protected $twig;
     protected $site;
     protected $filename;
-    
+
     public function __construct($filename, OutputInterface $output = null, $dest = null)
     {
         $this->filename = $filename;
@@ -28,43 +28,43 @@ class Blazon
             $output = new \Symfony\Component\Console\Output\NullOutput();
         }
         $this->output = $output;
-        
+
         $this->src = dirname($filename);
         $this->dest = $dest;
     }
-    
+
     public function getSrc()
     {
         return $this->src;
     }
-    
+
     public function getDest()
     {
         return $this->dest;
     }
-    
+
     public function getTwig()
     {
         return $this->twig;
     }
-    
+
     public function getOutput()
     {
         return $this->output;
     }
-    
+
     protected $pages = [];
-    
+
     public function addPage(Page $page)
     {
         $this->pages[$page->getName()] = $page;
     }
-    
+
     public function getSite()
     {
         return $this->site;
     }
-    
+
     public function getPages()
     {
         return $this->pages;
@@ -85,7 +85,7 @@ class Blazon
                     $this->dest = $dest;
                 }
             }
-        
+
             if (!$this->dest) {
                 $this->dest = dirname($this->filename) . '/build';
             }
@@ -99,19 +99,19 @@ class Blazon
                 $this->src = $src;
             }
         }
-        
+
         if (isset($config['site']['properties'])) {
             foreach ($config['site']['properties'] as $key => $value) {
                 $this->site->setProperty($key, $value);
             }
         }
-        
+
         if (isset($config['pages'])) {
             foreach ($config['pages'] as $name => $pageNode) {
                 $page = new Page($name, $pageNode);
-                
+
                 $handler = null;
-                    
+
                 if (isset($pageNode['src'])) {
                     $pageSrc = $this->src . '/' . $pageNode['src'];
                     if (!file_exists($pageSrc)) {
@@ -123,7 +123,7 @@ class Blazon
                     $handlerClassName = $pageNode['handler'];
                     $handler = new $handlerClassName($this);
                 }
-                
+
                 if (!$handler) {
                     if ($page->getSrc()=='') {
                         throw new RuntimeException("No handler and no src specified for page: " . $page->getName());
@@ -144,7 +144,7 @@ class Blazon
                 }
                 $page->setHandler($handler);
                 $handler->init($page, $config);
-            
+
 
                 if (isset($pageNode['properties'])) {
                     foreach ($pageNode['properties'] as $key => $value) {
@@ -155,26 +155,24 @@ class Blazon
                 $this->addPage($page);
             }
         }
-        
-        
+
+
         if (!file_exists($this->src)) {
             throw new RuntimeException("Source directory does not exist: " . $this->src);
         }
         if (!file_exists($this->dest)) {
-            if (!file_exists($this->dest)) {
-                mkdir($this->dest, 0755);
-            }
+            mkdir($this->dest, 0755);
         }
-        
+
         $loader = new \Twig_Loader_Filesystem($this->src);
-        
+
         $loader->addPath(
             $this->src . '/templates',
             'Templates'
         );
-        
+
         $this->twig = new \Twig_Environment($loader, []);
-        
+
         $filter = new \Twig_SimpleFilter('urlsafe_command_name', function (\Twig_Environment $env, $string) {
             // get the current charset for instance
             $string = str_replace(':', '__', $string);
@@ -184,7 +182,7 @@ class Blazon
 
         return $this;
     }
-    
+
     public function copyAssets($src, $dest, $process = true)
     {
         if (!file_exists($src)) {
@@ -202,7 +200,7 @@ class Blazon
             ),
             \RecursiveIteratorIterator::SELF_FIRST
         );
-        
+
         foreach ($iterator as $item) {
             if ($item->isDir()) {
                 $path = $dest . DIRECTORY_SEPARATOR . $iterator->getSubPathName();
@@ -220,7 +218,7 @@ class Blazon
                         throw new RuntimeException("Blocked: " . $iterator->getSubPathName());
                         break;
                 }
-                
+
                 if (!$process) {
                     copy($srcFile, $destFile);
                 } else {
@@ -240,7 +238,7 @@ class Blazon
             }
         }
     }
-    
+
     public function generate()
     {
         $this->output->writeLn('<info>Generating site</info>');
@@ -248,7 +246,7 @@ class Blazon
         $this->output->writeLn('   * src: ' . $this->src);
         $this->output->writeLn('   * dest: ' . $this->dest);
         $this->copyAssets($this->src . '/assets', $this->dest . '/assets');
-        
+
         foreach ($this->getPages() as $page) {
             $this->output->writeLn('Page: ' . $page->getName());
             $handler = $page->getHandler($this);
@@ -259,14 +257,14 @@ class Blazon
     public function init()
     {
         $this->load();
-        
+
         $this->output->writeLn('<info>Initializing site</info>');
         $this->output->writeLn('   * Filename: ' . $this->filename);
         $this->output->writeLn('   * src: ' . $this->src);
         $this->output->writeLn('   * dest: ' . $this->dest);
         $this->copyAssets($this->src . '/../static/assets', $this->dest . '/assets', false);
     }
-    
+
     public function run()
     {
         $this->load();

--- a/src/Blazon.php
+++ b/src/Blazon.php
@@ -152,6 +152,10 @@ class Blazon
                     }
                 }
 
+                if (isset($pageNode['title'])) {
+                    $page->setTitle($pageNode['title']);
+                }
+
                 $this->addPage($page);
             }
         }

--- a/src/Handler/CommandsHandler.php
+++ b/src/Handler/CommandsHandler.php
@@ -15,6 +15,10 @@ use Blazon\Model\Site;
 
 class CommandsHandler
 {
+    const CONF_CHILDNAME_STRATEGY = 'child_page_name_strategy';
+    const CHILDNAME_STRATEGY_PREFIX = 'prefix_with_parent_name';
+    const CHILDNAME_STRATEGY_NOPREFIX = 'no_prefix';
+
     protected $blazon;
 
     public function __construct(Blazon $blazon)
@@ -77,11 +81,22 @@ class CommandsHandler
      */
     protected function cmdNameToResourceName(Command $command, Page $parentPage)
     {
-        return sprintf(
-            '%s__%s.html',
-            $parentPage->getName(),
-            str_replace(':', '__', $command->getName())
-        );
+        $conf = $parentPage->getConfig();
+        $strategy = self::CHILDNAME_STRATEGY_PREFIX;
+
+        if (array_key_exists(self::CONF_CHILDNAME_STRATEGY, $conf)) {
+            $strategy =  $conf[self::CONF_CHILDNAME_STRATEGY];
+        }
+
+        if ($strategy === self::CHILDNAME_STRATEGY_PREFIX) {
+            return sprintf(
+                '%s__%s.html',
+                $parentPage->getName(),
+                str_replace(':', '__', $command->getName())
+            );
+        } else {
+            return sprintf('%s.html', str_replace(':', '__', $command->getName()));
+        }
     }
 
     /*

--- a/src/Handler/CommandsHandler.php
+++ b/src/Handler/CommandsHandler.php
@@ -52,7 +52,9 @@ class CommandsHandler
             $data = [
                 'site' => $site,
                 'page' => $page,
-                'command' => $command
+                'command' => $command,
+                'index_page' => $page, /* use this instead of page */
+                'index_page_url' => $pageOutputName,
             ];
             $output = $commandTemplate->render($data);
             file_put_contents($outputPath . $outputName, $output);

--- a/src/Handler/CommandsHandler.php
+++ b/src/Handler/CommandsHandler.php
@@ -34,7 +34,7 @@ class CommandsHandler
     {
         $site = $this->blazon->getSite();
         $config = $page->getConfig();
-        $outputPath = $this->blazon->getDest() . DIRECTORY_SEPARATOR;
+        $outputPath = $page->getBaseDir() . DIRECTORY_SEPARATOR;
 
         $pageName = $page->getName();
         $pageOutputName = $pageName . '.html';

--- a/src/Handler/CommandsHandler.php
+++ b/src/Handler/CommandsHandler.php
@@ -3,21 +3,18 @@
 namespace Blazon\Handler;
 
 use Blazon\Blazon;
-use Blazon\Model\Site;
 use Blazon\Model\Page;
-use Parsedown;
-use VKBansal\FrontMatter\Parser as FrontMatterParser;
-use VKBansal\FrontMatter\Document as FrontMatterDocument;
+use Blazon\Model\Site;
 
 class CommandsHandler
 {
     protected $blazon;
-    
+
     public function __construct(Blazon $blazon)
     {
         $this->blazon = $blazon;
     }
-    
+
     public function init(Page $page)
     {
         $config = $page->getConfig();
@@ -25,7 +22,7 @@ class CommandsHandler
             throw new RuntimeException("Pages with CommandsHandler require an array of `classes`");
         }
     }
-    
+
     public function generate(Page $page)
     {
         $config = $page->getConfig();
@@ -36,15 +33,15 @@ class CommandsHandler
 
             $template = $this->blazon->getTwig()->loadTemplate('@Templates/command.html.twig');
             $site = $this->blazon->getSite();
-            
+
             $data = [
                 'site' => $site,
                 'page' => $page,
                 'command' => $command
             ];
-            
+
             $output = $template->render($data);
-            
+
             $filename = $page->getName() . '__' . str_replace(':', '__', $command->getName()) . '.html';
             file_put_contents($this->blazon->getDest() . '/' . $filename, $output);
         }
@@ -52,20 +49,19 @@ class CommandsHandler
 
         $template = $this->blazon->getTwig()->loadTemplate('@Templates/commands.html.twig');
         $site = $this->blazon->getSite();
-        
+
         $data = [
             'site' => $site,
             'page' => $page,
             'commands' => $commands
         ];
-        
+
         $output = $template->render($data);
-        
+
         $filename = $page->getName() . '.html';
         file_put_contents($this->blazon->getDest() . '/' . $filename, $output);
 
-        //print_r($page->getConfig());
         return;
-        
+
     }
 }

--- a/src/Handler/HtmlHandler.php
+++ b/src/Handler/HtmlHandler.php
@@ -3,41 +3,38 @@
 namespace Blazon\Handler;
 
 use Blazon\Blazon;
-use Blazon\Model\Site;
 use Blazon\Model\Page;
-use Parsedown;
-use VKBansal\FrontMatter\Parser as FrontMatterParser;
-use VKBansal\FrontMatter\Document as FrontMatterDocument;
+use Blazon\Model\Site;
 
 class HtmlHandler
 {
     protected $blazon;
     protected $content;
-    
+
     public function __construct(Blazon $blazon)
     {
         $this->blazon = $blazon;
     }
-    
+
     public function init(Page $page, $config)
     {
     }
-    
+
     public function generate(Page $page)
     {
         $html = file_get_contents($this->blazon->getSrc() . '/' . $page->getSrc());
-        
+
         $template = $this->blazon->getTwig()->loadTemplate('templates/default.html.twig');
         $site = $this->blazon->getSite();
-        
+
         $data = [
             'content' => $html,
             'site' => $site,
             'page' => $page
         ];
-        
+
         $output = $template->render($data);
-        
+
         file_put_contents($this->blazon->getDest() . '/' . $page->getName() . '.html', $output);
     }
 }

--- a/src/Handler/HtmlHandler.php
+++ b/src/Handler/HtmlHandler.php
@@ -35,6 +35,6 @@ class HtmlHandler
 
         $output = $template->render($data);
 
-        file_put_contents($this->blazon->getDest() . '/' . $page->getName() . '.html', $output);
+        file_put_contents($page->getBaseDir() . '/' . $page->getName() . '.html', $output);
     }
 }

--- a/src/Handler/MarkdownHandler.php
+++ b/src/Handler/MarkdownHandler.php
@@ -52,6 +52,6 @@ class MarkdownHandler
 
         $output = $template->render($data);
 
-        file_put_contents($this->blazon->getDest() . '/' . $page->getName() . '.html', $output);
+        file_put_contents($page->getBaseDir() . '/' . $page->getName() . '.html', $output);
     }
 }

--- a/src/Handler/MarkdownHandler.php
+++ b/src/Handler/MarkdownHandler.php
@@ -2,23 +2,23 @@
 
 namespace Blazon\Handler;
 
-use Blazon\Blazon;
-use Blazon\Model\Site;
-use Blazon\Model\Page;
 use Parsedown;
 use VKBansal\FrontMatter\Parser as FrontMatterParser;
-use VKBansal\FrontMatter\Document as FrontMatterDocument;
+
+use Blazon\Blazon;
+use Blazon\Model\Page;
+use Blazon\Model\Site;
 
 class MarkdownHandler
 {
     protected $blazon;
     protected $content;
-    
+
     public function __construct(Blazon $blazon)
     {
         $this->blazon = $blazon;
     }
-    
+
     public function init(Page $page)
     {
         $data = file_get_contents($this->blazon->getSrc() . '/' . $page->getSrc());
@@ -35,23 +35,23 @@ class MarkdownHandler
         */
         $this->content = $doc->getContent();
     }
-    
+
     public function generate(Page $page)
     {
         $parsedown = new Parsedown();
         $html = $parsedown->text($this->content);
-        
+
         $template = $this->blazon->getTwig()->loadTemplate('templates/default.html.twig');
         $site = $this->blazon->getSite();
-        
+
         $data = [
             'content' => $html,
             'site' => $site,
             'page' => $page
         ];
-        
+
         $output = $template->render($data);
-        
+
         file_put_contents($this->blazon->getDest() . '/' . $page->getName() . '.html', $output);
     }
 }

--- a/src/Handler/TwigHandler.php
+++ b/src/Handler/TwigHandler.php
@@ -31,6 +31,6 @@ class TwigHandler
 
         $output = $template->render($data);
 
-        file_put_contents($this->blazon->getDest() . '/' . $page->getName() . '.html', $output);
+        file_put_contents($page->getBaseDir() . '/' . $page->getName() . '.html', $output);
     }
 }

--- a/src/Handler/TwigHandler.php
+++ b/src/Handler/TwigHandler.php
@@ -3,37 +3,34 @@
 namespace Blazon\Handler;
 
 use Blazon\Blazon;
-use Blazon\Model\Site;
 use Blazon\Model\Page;
-use Parsedown;
-use VKBansal\FrontMatter\Parser as FrontMatterParser;
-use VKBansal\FrontMatter\Document as FrontMatterDocument;
+use Blazon\Model\Site;
 
 class TwigHandler
 {
     protected $blazon;
-    
+
     public function __construct(Blazon $blazon)
     {
         $this->blazon = $blazon;
     }
-    
+
     public function init(Page $page)
     {
     }
-    
+
     public function generate(Page $page)
     {
         $template = $this->blazon->getTwig()->loadTemplate($page->getSrc());
         $site = $this->blazon->getSite();
-        
+
         $data = [
             'site' => $site,
             'page' => $page
         ];
-        
+
         $output = $template->render($data);
-        
+
         file_put_contents($this->blazon->getDest() . '/' . $page->getName() . '.html', $output);
     }
 }

--- a/src/Model/Page.php
+++ b/src/Model/Page.php
@@ -4,6 +4,7 @@ namespace Blazon\Model;
 
 class Page implements PageInterface
 {
+    protected $baseDir;
     protected $name;
     protected $title;
     protected $src;
@@ -86,5 +87,15 @@ class Page implements PageInterface
     {
         $this->config = $config;
         return $this;
+    }
+
+    public function getBaseDir()
+    {
+        return $this->baseDir;
+    }
+
+    public function setBaseDir($baseDir)
+    {
+        $this->baseDir = $baseDir;
     }
 }

--- a/src/Model/Page.php
+++ b/src/Model/Page.php
@@ -10,26 +10,26 @@ class Page implements PageInterface
     protected $handler;
     protected $layout;
     protected $config;
-        
+
     use PropertyTrait;
-    
+
     public function __construct($name, $config = [])
     {
         $this->setName($name);
         $this->config = $config;
     }
-    
+
     public function getName()
     {
         return $this->name;
     }
-    
+
     public function setName($name)
     {
         $this->name = $name;
         return $this;
     }
-    
+
     public function getTitle()
     {
         if (!$this->title) {
@@ -37,57 +37,54 @@ class Page implements PageInterface
         }
         return $this->title;
     }
-    
+
     public function setTitle($title)
     {
         $this->title = $title;
         return $this;
     }
-    
+
     public function getSrc()
     {
         return $this->src;
     }
-    
+
     public function setSrc($src)
     {
         $this->src = $src;
         return $this;
     }
-    
+
     public function getHandler()
     {
         return $this->handler;
     }
-    
+
     public function setHandler($handler)
     {
         $this->handler = $handler;
         return $this;
     }
-    
+
     public function getLayout()
     {
         return $this->layout;
     }
-    
+
     public function setLayout($layout)
     {
         $this->layout = $layout;
         return $this;
     }
-    
+
     public function getConfig()
     {
         return $this->config;
     }
-    
+
     public function setConfig($config)
     {
         $this->config = $config;
         return $this;
     }
-    
-    
-    
 }


### PR DESCRIPTION
The main improvements are:-

- CommandsHandler creates Command instances without fully constructing them, side-stepping the need to inject dependencies just to get at the Command config

- Blazon creates the output directory structure so that handlers can now cope with nested pages; for example:-

        configuration-reference/index: # --> $dest/configuration-reference/index.html
            src: "doc/configuration-reference/index.md"

- CommandsHandler allows a different naming scheme for Command pages - one without having the the command page name prefixed with the parent page name; for example, both of these work:-

        command-reference/index # --> $dest/command-reference/apt-get__install.html
            child_page_name_strategy: "no_prefix"

        commands # --> $dest/commands__apt-get__install.html
            child_page_name_strategy: "prefix_with_parent_name"

        commands # --> $dest/commands__apt-get__install.html (default strategy)

Minor Improvements:

- set page title from the config
- command template now receives `index_page_url` so it doesn't need to construct a link back to the index